### PR TITLE
add real_gm scenario

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "co": "^4.6.0",
     "colors": "^1.1.2",
     "cson": "^3.0.2",
+    "minimist": "^1.2.0",
     "mongoose": "^4.2.10",
     "nightmare": "https://github.com/segmentio/nightmare.git"
   }

--- a/scenarios/real_gm.coffee
+++ b/scenarios/real_gm.coffee
@@ -1,0 +1,54 @@
+Scenario = require '../src/scenario'
+Gunslinger = require '../src/gunslinger'
+
+incorrect_selectors = [
+	'd'
+	'*'
+	'#woo'
+	'header, footer'
+]
+correct_selector = 'article'
+
+module.exports = (gameSessionId) ->
+	number_of_players = 3
+
+	scenario = new Scenario
+
+	scenario
+		.repeat number_of_players, (index) ->
+			@db_account "fake-player-#{index}"
+
+		.use_game_session gameSessionId
+
+		.repeat number_of_players, (index) ->
+			@spawn \
+				"fake-player-#{index}",
+				gameSessionId
+
+		.async ->
+			@repeat number_of_players, (index) ->
+				@as "fake-player-#{index}", ->
+					@wait_cell 'round_phase', 'in_progress'
+					@repeat 10, -> [
+						@wait Gunslinger.any_in_range [50, 75]
+						do @refresh
+						@exchange
+							send:
+								cell: 'selector'
+								value: Gunslinger.any_of incorrect_selectors
+							assert:
+								match: ({ result }) -> result is 'negative'
+					]
+					@wait Gunslinger.any_in_range [100, 500]
+
+					@exchange
+						send:
+							cell: 'selector'
+							value: correct_selector
+						assert:
+							match: ({ result }) -> result is 'positive'
+
+		.repeat number_of_players, (index) ->
+			@end "fake-player-#{index}"
+
+	scenario

--- a/src/gunslinger.coffee
+++ b/src/gunslinger.coffee
@@ -155,6 +155,9 @@ Gunslinger =
 			game_master_id: @fake_accounts[game_master_id]._id
 		@game_sessions[id] = game_session._id
 
+	use_game_session: ({ id }) ->
+		@game_sessions[id] = id
+
 	service: ->
 		yield new Promise (resolve) =>
 			cwd = @configuration.service_path

--- a/src/scenario.coffee
+++ b/src/scenario.coffee
@@ -46,6 +46,9 @@ class Scenario
 	db_game_session: (id, game_master_id) ->
 		@method 'db_game_session', { id,  game_master_id }
 
+	use_game_session: (id) ->
+		@method 'use_game_session', { id }
+
 	service: ->
 		@method 'service', {}
 

--- a/test-real-gm.coffee
+++ b/test-real-gm.coffee
@@ -1,0 +1,15 @@
+argv = (require 'minimist') process.argv.slice 2
+
+mongoose = require 'mongoose'
+
+Gunslinger = require './src/gunslinger'
+create_scenario = require './scenarios/real_gm'
+
+{connection} = mongoose.connect 'mongodb://localhost/cssqd-test'
+connection.once 'open', ->
+
+	Gunslinger.run create_scenario argv.session_id
+		.then ->
+			console.log 'all done!'
+			do process.exit
+			do done


### PR DESCRIPTION
This new scenario allows you to act as real gm and watch all the weird stuff gunslingers do 😼 

**Prerequisites**:
- create `cssqd-test` db with gamesessions/puzzles/users collections (as far as I know, there is no such functionality in robomongo, try [mongochef](http://3t.io/mongochef/))
- start cssqd on dev env `npm run dev`
- login as game master (this step is needed to set `koa:sess` cookie)
- shut down service
- start cssqd on dev-test env `npm run dev-test`
- go to `http://localhost:3000/game?id=<game-session-id>&user_id=<your-gm-id>`
- `cd gunslinger`
- make some popcorn and get ready to be amazed
- ready?  `coffee test-real-gm.coffee --session_id <your game session id>`
